### PR TITLE
[feature] Implements router arguments binding

### DIFF
--- a/common/decorators/controller.ts
+++ b/common/decorators/controller.ts
@@ -1,11 +1,27 @@
-import { CONTROLLER_META_PROPKEY, MetaKeys } from '../../constants.ts';
+// deno-lint-ignore-file ban-types
+import { CONTROLLER_META_PROPKEY } from '../../constants.ts';
 import { ConstructableFunc, RouteDefinition } from '../../defs.ts';
 import { Reflect } from '../../deps.ts';
+
+export enum RouteParamType {
+  BODY = 'body',
+  PARAM = 'param',
+  QUERY = 'query',
+  HEADER = 'header',
+}
+
+export interface RouteArgumentMeta {
+  type: RouteParamType;
+  key?: string;
+  index: number;
+  argValue: string | symbol;
+}
 
 export interface ControllerMetadata {
   prefix: string;
   routes: Map<string | symbol, RouteDefinition>;
   isSingleton: boolean;
+  routeArgsMap: Map<string | symbol, Array<RouteArgumentMeta>>;
 }
 
 export function defaultMetadata(): ControllerMetadata {
@@ -13,6 +29,7 @@ export function defaultMetadata(): ControllerMetadata {
     prefix: '/',
     routes: new Map<string, RouteDefinition>(),
     isSingleton: true,
+    routeArgsMap: new Map<string | symbol, Array<RouteArgumentMeta>>(),
   };
 }
 
@@ -22,4 +39,12 @@ export function Controller<T>(prefix = '/') {
     meta.prefix = prefix;
     Reflect.defineMetadata(CONTROLLER_META_PROPKEY, meta, target);
   };
+}
+
+export function setControllerMetaData(target: Object, value: ControllerMetadata): void {
+  Reflect.defineMetadata(CONTROLLER_META_PROPKEY, value, target.constructor);
+}
+
+export function getControllerMeta(target: Object): ControllerMetadata | undefined {
+  return Reflect.getMetadata(CONTROLLER_META_PROPKEY, target.constructor);
 }

--- a/common/decorators/http/route.param.ts
+++ b/common/decorators/http/route.param.ts
@@ -1,0 +1,56 @@
+import {
+  ControllerMetadata,
+  defaultMetadata,
+  getControllerMeta,
+  RouteArgumentMeta,
+  RouteParamType,
+  setControllerMetaData,
+} from '../controller.ts';
+
+/**
+ * A parameter decorator maps `context.request.body()`
+ *
+ * ```ts
+ * public controllerAction(@Body('name') name: string): any { }
+ * ```
+ *
+ * @param key The key of the value to be retrieved
+ * @returns if `key` is specified, return the value of the key from the payload.
+ *          otherwise, returns whole `request.body`
+ */
+export function Body(key?: string): ParameterDecorator {
+  return defineRouteParamDecorator(RouteParamType.BODY, key);
+}
+
+export function Param(key?: string): ParameterDecorator {
+  return defineRouteParamDecorator(RouteParamType.PARAM, key);
+}
+
+export function Query(key?: string): ParameterDecorator {
+  return defineRouteParamDecorator(RouteParamType.QUERY, key);
+}
+
+export function Header(key?: string): ParameterDecorator {
+  return defineRouteParamDecorator(RouteParamType.HEADER, key);
+}
+
+export const defineRouteParamDecorator =
+  (argType: RouteParamType, paramKey?: string): ParameterDecorator =>
+  (target: any, key: string | symbol, index: number): void => {
+    const meta: ControllerMetadata = getControllerMeta(target) ?? defaultMetadata();
+
+    const argMeta: RouteArgumentMeta = {
+      type: argType,
+      key: paramKey,
+      index,
+      argValue: key,
+    };
+
+    if (meta.routeArgsMap.has(key)) {
+      const mapValue = meta.routeArgsMap.get(key);
+      mapValue!.push(argMeta);
+    } else {
+      meta.routeArgsMap.set(key, [argMeta]);
+    }
+    setControllerMetaData(target, meta);
+  };

--- a/common/decorators/index.ts
+++ b/common/decorators/index.ts
@@ -2,3 +2,4 @@ export * from './controller.ts';
 export * from './injectable.ts';
 export * from './methods.ts';
 export * from './module.ts';
+export * from './http/route.param.ts';

--- a/examples/example.controller.ts
+++ b/examples/example.controller.ts
@@ -1,22 +1,45 @@
-import { ApiEndpoint, Controller } from '../common/decorators/index.ts';
+import { Body, Header, Query } from '../common/decorators/http/route.param.ts';
+import { ApiEndpoint, Controller, Param } from '../common/decorators/index.ts';
 import { HttpMethod } from '../defs.ts';
 import { ExampleService } from './example.service.ts';
 
-@Controller('/aa')
+@Controller('/stne')
 export class ExampleController {
   constructor(public service: ExampleService) {
     console.log('ExampleController is created!');
   }
 
-  @ApiEndpoint('/b', HttpMethod.GET)
+  @ApiEndpoint('/getTest', HttpMethod.GET)
   public bbb(): Promise<string> {
     return new Promise((resolve) => {
       resolve('bbb');
     });
   }
 
-  @ApiEndpoint('/c', HttpMethod.GET)
+  @ApiEndpoint('/getTest2', HttpMethod.GET)
   public async ccc(): Promise<string> {
     return await this.service.ex1();
+  }
+
+  @ApiEndpoint('/postTest', HttpMethod.POST)
+  public async postTest(): Promise<string> {
+    return await this.service.ex1();
+  }
+
+  @ApiEndpoint('/getTest3/:id', HttpMethod.GET)
+  public getTest3(
+    @Param('id') id: number,
+    @Header('accept') header: any,
+    @Query('name') name: string
+  ): Promise<string> {
+    console.log('accept', header);
+    return this.service.getThree(id, name);
+  }
+
+  @ApiEndpoint('/postTest1/:id', HttpMethod.POST)
+  public postTest1(@Body() body: any): Promise<string> {
+    return new Promise((resolve) => {
+      resolve(`postTest1 ${body}`);
+    });
   }
 }

--- a/examples/example.service.ts
+++ b/examples/example.service.ts
@@ -10,4 +10,10 @@ export class ExampleService {
       resolve('this is from service.ex1');
     });
   }
+
+  public getThree(id: number, name: string): Promise<string> {
+    return new Promise((resolve) => {
+      resolve(`${id} : ${name}`);
+    });
+  }
 }

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -3,6 +3,6 @@ import { GlobalModules } from './app-modules.ts';
 
 const app: Application = new Application({ modules: [GlobalModules] });
 
-const PORT = 8000;
+const PORT = 8001;
 
 await app.run(PORT);

--- a/router.ts
+++ b/router.ts
@@ -1,7 +1,10 @@
-import { ControllerMetadata } from './common/decorators/controller.ts';
+import { ControllerMetadata, RouteArgumentMeta, RouteParamType } from './common/decorators/controller.ts';
 import { RouteDefinition } from './defs.ts';
 import { Middleware, Router as OakRouter, RouterContext } from './deps.ts';
 import { ControllerContainer } from './injector/defs.ts';
+
+// deno-lint-ignore no-explicit-any
+type OakContext = RouterContext<any>;
 
 export class Router extends OakRouter {
   #bootstrapMsg = 'STNE Framework\n';
@@ -24,13 +27,79 @@ export class Router extends OakRouter {
 
       // deno-lint-ignore ban-types no-explicit-any
       (<Function>this[route.requestMethod])(normalizedPath, async (context: RouterContext<any>): Promise<void> => {
+        const metaArgs = controller.meta.routeArgsMap.get(route.methodName) || [];
+        const args = await this.#transformArguments(metaArgs, context);
+
+        // FIXME If 'Content-Type: application/json' header is not specified, the body will return URLSearchParam.
+
         // deno-lint-ignore no-explicit-any
-        const result = await (controller.instance() as any)[route.methodName](); //.apply();
+        const result = await (controller.instance() as any)[route.methodName](...args);
         context.response.body = result;
-        context.response.status = 200; // TODO result가 status 까지 줘야함
+
+        // default HTTP response
+        context.response.status = 200; // TODO `result` should return result and status
       });
     });
     this.#appendToBootstrapMsg('');
+  }
+
+  /**
+   * Transform route meta data to it's value
+   *
+   * @param routeArgs The Arguments of route methods' meta data
+   * @param context Context of Oak
+   * @returns the value of the arguments to bind
+   */
+  async #transformArguments(routeArgs: RouteArgumentMeta[], context: OakContext): Promise<any[]> {
+    const { params, queries, body, headers } = await this.#getRequestProperties(context);
+
+    // The ordering of incomming arguments are weird, not matched to order of the arguments on the source code.
+    // So, sorting must be.
+    routeArgs.sort((a, b) => a.index - b.index);
+    return routeArgs.map((v) => {
+      switch (v.type) {
+        case RouteParamType.BODY:
+          return body;
+        case RouteParamType.HEADER:
+          return v.key ? headers[v.key] : headers;
+        case RouteParamType.PARAM:
+          return v.key ? params[v.key] : params;
+        case RouteParamType.QUERY:
+          return v.key ? queries[v.key] : queries;
+      }
+    });
+  }
+
+  /**
+   * Get params, headers, queries, body from the given context
+   *
+   * @param context Oak context
+   */
+  async #getRequestProperties(context: OakContext): Promise<ResultGetRequestProperties> {
+    // context 에서 param, header, query, body 를 가져온다.
+    const { headers, url } = context.request;
+
+    const headersCopy: Record<string, string> = {};
+    for (const [k, v] of headers.entries()) {
+      headersCopy[k] = v;
+    }
+
+    const queries: Record<string, string> = {};
+    for (const [k, v] of url.searchParams.entries()) {
+      queries[k] = v;
+    }
+
+    const params: Record<string, string> = {};
+    for (const [k, v] of Object.entries(context.params)) {
+      params[k] = v;
+    }
+
+    return {
+      params: params,
+      headers: headersCopy,
+      queries,
+      body: context.request.hasBody ? await context.request.body().value : undefined,
+    };
   }
 
   #normalizePath(prefix: string, path: string): string {
@@ -49,4 +118,11 @@ export class Router extends OakRouter {
   middleware(): Middleware {
     return this.routes();
   }
+}
+
+interface ResultGetRequestProperties {
+  params: Record<string, string>;
+  headers: Record<string, string>;
+  body: any;
+  queries: Record<string, string>;
 }


### PR DESCRIPTION
Add `@Param()`, `@Headers`, `@Body()`, `@Query()` decorators to bind context properties to router arguments.

resolved #1 , #2 